### PR TITLE
Common chunk

### DIFF
--- a/src/server/app-shell-handler.js
+++ b/src/server/app-shell-handler.js
@@ -47,10 +47,12 @@ module.exports = function renderAppShell(req, res) {
 
     const contentType = initialState.context.contentType;
     const chunkPreloadLink = contentType
-      ? `<link rel="preload" href="/public/js/${contentType}.chunk.js" as="script">`
+      ? `<link rel="preload" href="/public/js/common.chunk.js" as="script">
+         <link rel="preload" href="/public/js/${contentType}.chunk.js" as="script">`
       : '';
     const chunkScript = contentType
-      ? `<script defer src="/public/js/${contentType}.chunk.js"></script>`
+      ? `<script defer src="/public/js/common.chunk.js"></script>
+         <script defer src="/public/js/${contentType}.chunk.js"></script>`
       : '';
 
     res.send(`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,14 @@ const commonConfig = {
     path: PATHS.build
   },
   plugins: [
+    new webpack.optimize.CommonsChunkPlugin({
+      // the entry point name
+      name: 'app-shell',
+      // how we name the common chunk
+      async: 'common',
+      // all chunks
+      children: true
+    }),
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV)


### PR DESCRIPTION
Use a common chunk to ensure no duplicated code across each page chunk. The `app-shell.js` will also have all the remaining shared code (React etc..).